### PR TITLE
Converting JSON keys to symbols when parsing complex TEXT attributes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 
 rvm:
   - 2.2.7

--- a/lib/occi/core/parsers/text/entity.rb
+++ b/lib/occi/core/parsers/text/entity.rb
@@ -25,7 +25,7 @@ module Occi
           DEFAULT_LAMBDA  = ->(val) { raise "#{self} -> Cannot typecast #{val.inspect} to an unknown type" }
 
           FLOAT_LAMBDA    = ->(val) { Float(val) rescue raise(Occi::Core::Errors::ParsingError, "Wrong value #{val}") }
-          JSON_LAMBDA     = ->(val) { JSON.parse(val.gsub('\"', '"')) }
+          JSON_LAMBDA     = ->(val) { JSON.parse(val.gsub('\"', '"'), symbolize_names: true) }
 
           TYPECASTER_HASH = {
             IPAddr  => ->(val) { IPAddr.new val },


### PR DESCRIPTION
At the moment, this is applicable only to `occi.securitygroup.rules` attribute on `Occi::InfrastructureExt::SecurityGroup`.