### PR TITLE
[CI] Disabling `RSpec/ExpectInHook` matchers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -2,3 +2,7 @@ Style/RescueModifier:
   Exclude:
   - 'lib/occi/core/parsers/json/entity.rb'
   - 'lib/occi/core/parsers/text/entity.rb'
+
+RSpec/ExpectInHook:
+  Exclude:
+  - 'spec/occi/core/**/*'


### PR DESCRIPTION
Fixes broken `rubocop` tests (temporarily).