### PR TITLE
Relaxing strict Regexp patterns on attrs

### DIFF
--- a/lib/occi/core/warehouse/kinds/attributes/occi.core.title.yml
+++ b/lib/occi/core/warehouse/kinds/attributes/occi.core.title.yml
@@ -4,4 +4,4 @@ required: false
 mutable: true
 default: ~
 description: Title assigned to this entity sub-type instance.
-pattern: !ruby/regexp '/^[[:word:]]([[:blank:]]|[[:word:]]|\-)*$/'
+pattern: !ruby/regexp '/^.+$/'

--- a/lib/occi/infrastructure/warehouse/actions/compute_save.yml
+++ b/lib/occi/infrastructure/warehouse/actions/compute_save.yml
@@ -16,4 +16,4 @@ attributes:
     mutable: true
     default: ~
     description: Name of the copy
-    pattern: !ruby/regexp '/^[[:alnum:]]+$/'
+    pattern: !ruby/regexp '/^.+$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.compute.hostname.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.compute.hostname.yml
@@ -4,4 +4,4 @@ required: false
 mutable: true
 default: ~
 description: Compute FQDN.
-pattern: ~
+pattern: !ruby/regexp '/^.+$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.compute.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.compute.state.message.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Human-readable description of the current state.
-pattern: ~
+pattern: !ruby/regexp '/^.*$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.network.label.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.network.label.yml
@@ -4,4 +4,4 @@ required: false
 mutable: true
 default: ~
 description: Label of the network instance.
-pattern: ~
+pattern: !ruby/regexp '/^.+$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.network.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.network.state.message.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Human-readable description of the current state.
-pattern: ~
+pattern: !ruby/regexp '/^.*$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.networkinterface.interface.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.networkinterface.interface.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Network interface name.
-pattern: !ruby/regexp '/^[[:alnum:]]+$/'
+pattern: !ruby/regexp '/^.+$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.networkinterface.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.networkinterface.state.message.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Human-readable description of the current state.
-pattern: ~
+pattern: !ruby/regexp '/^.*$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storage.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storage.state.message.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Human-readable description of the current state.
-pattern: ~
+pattern: !ruby/regexp '/^.*$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storagelink.deviceid.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storagelink.deviceid.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Block device ID.
-pattern: !ruby/regexp '/^([[:alnum:]]|-|_|\/)+$/'
+pattern: !ruby/regexp '/^.+$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storagelink.mountpoint.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storagelink.mountpoint.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Block device mount point.
-pattern: ~
+pattern: !ruby/regexp '/^.+$/'

--- a/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storagelink.state.message.yml
+++ b/lib/occi/infrastructure/warehouse/kinds/attributes/occi.storagelink.state.message.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Human-readable description of the current state.
-pattern: ~
+pattern: !ruby/regexp '/^.*$/'

--- a/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.ipreservation.state.message.yml
+++ b/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.ipreservation.state.message.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Human-readable description of the current state.
-pattern: ~
+pattern: !ruby/regexp '/^.*$/'

--- a/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.securitygroup.state.message.yml
+++ b/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.securitygroup.state.message.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Human-readable description of the current state.
-pattern: ~
+pattern: !ruby/regexp '/^.*$/'

--- a/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.securitygrouplink.state.message.yml
+++ b/lib/occi/infrastructure_ext/warehouse/kinds/attributes/occi.securitygrouplink.state.message.yml
@@ -4,4 +4,4 @@ required: false
 mutable: false
 default: ~
 description: Human-readable description of the current state.
-pattern: ~
+pattern: !ruby/regexp '/^.*$/'


### PR DESCRIPTION
* Relaxing patterns on (mostly) free-text attributes
* Replacing `~` with a permissive pattern to align behavior